### PR TITLE
feat: use project name/version instead of hard coded values

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ To support testing firmware updates you will need to build two versions of the s
 
 3. You should also flash the version to the esp32 microcontroller
 
-4. Build a new version, but edit the `APPLICATION_VERSION` and set to a new version, e.g. `1.2.0`
+4. Build a new version, by doing a new git commit
 
    ```sh
    idf.py build


### PR DESCRIPTION
Use the `esp_app_get_description` function to retrieve the meta information about the project (e.g. name and version).

Using the official project version makes the build process easier as a version does not have to be updated in the source code when a new release is available.